### PR TITLE
Dirty entity is autoflushed when session is closed #70

### DIFF
--- a/src/main/java/com/breskul/bibernate/persistence/Session.java
+++ b/src/main/java/com/breskul/bibernate/persistence/Session.java
@@ -194,7 +194,6 @@ public class Session implements AutoCloseable {
    */
   @Override
   public void close() {
-    performDirtyChecking();
     persistenceContext.clear();
     actionQueue.clear();
     sessionStatus = false;


### PR DESCRIPTION
Entity with dirty state should flush its changes only when `Session.flush()` method is called.